### PR TITLE
fix: skip duplicate TypeWrapper registration for MinMaxBounds.Ints

### DIFF
--- a/Common/src/main/java/com/almostreliable/lootjs/kube/LootJSPlugin.java
+++ b/Common/src/main/java/com/almostreliable/lootjs/kube/LootJSPlugin.java
@@ -82,8 +82,13 @@ public class LootJSPlugin extends KubeJSPlugin {
     public void registerTypeWrappers(ScriptType type, TypeWrappers typeWrappers) {
         typeWrappers.registerSimple(LootEntry.class, LootEntryWrapper::of);
         typeWrappers.registerSimple(MinMaxBounds.Doubles.class, IntervalJS::ofDoubles);
-        typeWrappers.registerSimple(MinMaxBounds.Ints.class, IntervalJS::ofInt);
-
+        
+        try {
+            typeWrappers.registerSimple(MinMaxBounds.Ints.class, IntervalJS::ofInt);
+        } catch (IllegalArgumentException ignored) {
+            // Wrapper already registered by KubeJS, skip
+        }
+        
         typeWrappers.registerSimple(ItemFilter.class, o -> {
             if (o instanceof List<?> list) {
                 Map<Boolean, ? extends List<?>> split = list


### PR DESCRIPTION
## Problem
KubeJS 2001.6.5 now registers a TypeWrapper for MinMaxBounds.Ints natively.
LootJS then tries to register it again in LootJSPlugin#registerTypeWrappers(),
causing an IllegalArgumentException crash on startup.

## Fix
Wrapped the registerSimple() call for MinMaxBounds.Ints in a try/catch to
silently skip registration if the wrapper already exists.

## Reproduction
- KubeJS forge-2001.6.5-build.14+
- LootJS forge-1.20.1-2.13.1
- Rhino forge-2001.2.3-build.10

## Tested
- Minecraft 1.20.1 Forge 47.4.6
- KubeJS forge-2001.6.5-build.16
- LootJS forge-1.20.1-2.13.1 (this fix)
- Rhino forge-2001.2.3-build.10
- Woot Revived

Game boots successfully, no crash on startup.


[crash-2026-04-05_13.25.40-fml.txt](https://github.com/user-attachments/files/26488379/crash-2026-04-05_13.25.40-fml.txt)
